### PR TITLE
padrino-gen が bundler 2 を受け入れるように

### DIFF
--- a/padrino-gen/padrino-gen.gemspec
+++ b/padrino-gen/padrino-gen.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.rdoc_options  = ["--charset=UTF-8"]
 
   s.add_dependency("padrino-core", Padrino.version)
-  s.add_dependency("bundler", "~> 1.0")
+  s.add_dependency("bundler", ">= 1.0", "< 3.0")
   s.add_development_dependency("padrino-helpers", Padrino.version)
   s.add_development_dependency("padrino-mailer", Padrino.version)
 end


### PR DESCRIPTION
padrino-gen が bundler 1 だけでなく 2 も受け入れるようにします。
https://github.com/padrino/padrino-framework/pull/2206 のように単に指定を消さないのは未来に出てくる bundler3 以降が許容できるものかどうか現時点ではわからないためです。